### PR TITLE
Fixes for autotools

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -103,7 +103,7 @@ EXTRA_DIST += \
 	      ratbagd.service.in \
 	      dbus/org.freedesktop.ratbag1.service.in \
 	      dbus/org.freedesktop.ratbag1.conf
-BUILT_SOURCES += ratbagd.service dbus/org.freedesktop.ratbag1.service
+BUILT_SOURCES += ratbagd.service dbus/org.freedesktop.ratbag1.service dbus/org.freedesktop.ratbag1.conf
 
 # ------------------------------------------------------------------------------
 # python module

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ installation of the following files:
     sudo cp ratbagd.service /etc/systemd/system/ratbagd.service
 
 The files are installed into the prefix by make install, see also the
-configure switches ---with-systemd-uint-dir and --with-dbus-root-dir.
+configure switches ---with-systemd-unit-dir, --with-dbus-services-dir and
+--with-dbus-config-dir.
 Developers are encouraged to simply symlink to the files in the git
 repository.
 

--- a/configure.ac
+++ b/configure.ac
@@ -133,14 +133,21 @@ AC_ARG_WITH([systemd-unit-dir],
 SYSTEMD_UNIT_DIR=${unitdir}
 AC_SUBST(SYSTEMD_UNIT_DIR)
 
-AC_ARG_WITH([dbus-root-dir],
-	    AS_HELP_STRING([--with-dbus-root-dir=DIR],
+AC_ARG_WITH([dbus-services-dir],
+	    AS_HELP_STRING([--with-dbus-services-dir=DIR],
 			   [dbus service directory [[default=$datadir/dbus-1]]]),
-	    [unitdir="$withval"],
-	    [unitdir="$datadir/dbus-1"])
-DBUS_SYSTEM_SERVICES_DIR="${datadir}/system-services"
-DBUS_SYSTEM_CONFIG_DIR="${datadir}/system.d"
+	    [dbussrvdir="$withval"],
+	    [dbussrvdir="$datadir/dbus-1"])
+DBUS_SYSTEM_SERVICES_DIR="${dbussrvir}"
 AC_SUBST(DBUS_SYSTEM_SERVICES_DIR)
+
+AC_ARG_WITH([dbus-config-dir],
+	    AS_HELP_STRING([--with-dbus-config-dir=DIR],
+			   [dbus service directory [[default=$datadir/system.d]]]),
+	    [dbusconfdir="$withval"],
+	    [dbusconfdir="$datadir/system.d"])
+DBUS_SYSTEM_CONFIG_DIR="${dbusconfdir}"
+AC_SUBST(DBUS_SYSTEM_CONFIG_DIR)
 
 # ------------------------------------------------------------------------------
 # report
@@ -156,6 +163,10 @@ AC_MSG_RESULT([
         exec_prefix:            ${exec_prefix}
         includedir:             ${includedir}
         libdir:                 ${libdir}
+
+        systemd-unit-dir:       ${unitdir}
+        dbus-services-dir:      ${dbussrvdir}
+        dbus-config-dir:        ${dbusconfdir}
 
         CFLAGS:                 ${OUR_CFLAGS} ${CFLAGS}
         CPPFLAGS:               ${OUR_CPPFLAGS} ${CPPFLAGS}


### PR DESCRIPTION
the org.freedesktop.ratbag1.conf was actually a xml file. I checked on my system and they all have the xml extension so I changed that.
Then I fixed the autotools files to be able to install the xml and the service file to separate locations and updated the README accordingly.
