### PR TITLE
python: catch more DBus exceptions

### DIFF
--- a/python/ratbagd/__init__.py
+++ b/python/ratbagd/__init__.py
@@ -49,7 +49,7 @@ class _RatbagdDBus(object):
         except GLib.GError:
             raise RatbagdDBusUnavailable()
 
-        if self._proxy.get_name_owner() == None:
+        if self._proxy.get_name_owner() is None:
             raise RatbagdDBusUnavailable()
 
     def dbus_property(self, property):


### PR DESCRIPTION
`Gio.bus_get_sync` may return `None` when the DBus service is not available (see libratbag/piper#2). In addition to this, the service may time out when it is being started in which case `Gio.DBusProxy.new_sync` will raise a `GLib.Gerror`.

This commit checks for both scenarios and raises a `RatbagdDBusUnavailable`
exception when either one of them occurs. This will in turn be caught in for
example Piper to properly deal with this. This fixes libratbag/piper#2.

@whot  I hope this is acceptable as my mandatory GSoC contribution to Piper!