### PR TITLE
Add signals to the Profile and Resolution interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ The **org.freedesktop.ratbag1.Profile** interface provides:
 - Methods:
   - SetActive(void) -> set this profile to be the active profile
   - GetResolutionByIndex(uint) -> returns the object path for the given index
+- Signals:
+  - ActiveProfileChanged -> active profile changed, carries index of the currently active profile
 
 The **org.freedesktop.ratbag1.Resolution** interface provides:
 - Properties:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The **org.freedesktop.ratbag1.Profile** interface provides:
   - SetActive(void) -> set this profile to be the active profile
   - GetResolutionByIndex(uint) -> returns the object path for the given index
 - Signals:
-  - ActiveProfileChanged -> active profile changed, carries index of the currently active profile
+  - ActiveProfileChanged -> active profile changed, carries index of the new active profile
 
 The **org.freedesktop.ratbag1.Resolution** interface provides:
 - Properties:
@@ -67,7 +67,7 @@ The **org.freedesktop.ratbag1.Resolution** interface provides:
   - SetResolution(uint, uint) -> x/y resolution to assign
   - SetReportRate(uint) -> uint for the report rate to assign
 - Signals:
-  - ActiveResolutionChanged -> active resolution changed, carries index of the currently active resolution
+  - ActiveResolutionChanged -> active resolution changed, carries index of the new active resolution
 
 The **org.freedesktop.ratbag1.Button** interface provides:
 - Properties:

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ The **org.freedesktop.ratbag1.Resolution** interface provides:
 - Methods:
   - SetResolution(uint, uint) -> x/y resolution to assign
   - SetReportRate(uint) -> uint for the report rate to assign
+- Signals:
+  - ActiveResolutionChanged -> active resolution changed, carries index of the currently active resolution
 
 The **org.freedesktop.ratbag1.Button** interface provides:
 - Properties:

--- a/src/ratbagd-profile.c
+++ b/src/ratbagd-profile.c
@@ -245,6 +245,13 @@ static int ratbagd_profile_set_active(sd_bus_message *m,
 	if (r < 0)
 		return r;
 
+	(void) sd_bus_emit_signal(sd_bus_message_get_bus(m),
+				  "/org/freedesktop/ratbag1",
+				  "/org.freedesktop.ratbag1.Profile",
+				  "ActiveProfileChanged",
+				  "u",
+				  profile->index);
+
         return sd_bus_reply_method_return(m, "u",
                                           ratbag_profile_set_active(profile->lib_profile));
 }
@@ -279,6 +286,7 @@ const sd_bus_vtable ratbagd_profile_vtable[] = {
 	SD_BUS_PROPERTY("DefaultResolution", "u", ratbagd_profile_get_default_resolution, 0, 0),
 	SD_BUS_METHOD("SetActive", "", "u", ratbagd_profile_set_active, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("GetResolutionByIndex", "u", "o", ratbagd_profile_get_resolution_by_index, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_SIGNAL("ActiveProfileChanged", "u", 0),
 	SD_BUS_VTABLE_END,
 };
 

--- a/src/ratbagd-resolution.c
+++ b/src/ratbagd-resolution.c
@@ -86,6 +86,14 @@ static int ratbagd_resolution_set_resolution(sd_bus_message *m,
 		resolution->xres = xres;
 		resolution->yres = yres;
 	}
+
+	(void) sd_bus_emit_signal(sd_bus_message_get_bus(m),
+				  "/org/freedesktop/ratbag1",
+				  "/org.freedesktop.ratbag1.Resolution",
+				  "ActiveResolutionChanged",
+				  "u",
+				  resolution->index);
+
 	return sd_bus_reply_method_return(m, "u", r);
 }
 
@@ -133,6 +141,7 @@ const sd_bus_vtable ratbagd_resolution_vtable[] = {
 	SD_BUS_PROPERTY("ReportRate", "u", NULL, offsetof(struct ratbagd_resolution, rate), SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
 	SD_BUS_METHOD("SetReportRate", "u", "u", ratbagd_resolution_set_report_rate, SD_BUS_VTABLE_UNPRIVILEGED),
 	SD_BUS_METHOD("SetResolution", "uu", "u", ratbagd_resolution_set_resolution, SD_BUS_VTABLE_UNPRIVILEGED),
+	SD_BUS_SIGNAL("ActiveResolutionChanged", "u", 0),
 	SD_BUS_VTABLE_END,
 };
 


### PR DESCRIPTION
Currently this only holds the commit adding a signal for active profile changes to the Profile interface, hence its WIP status. I'll add the other commits as I finish them.

Closes #7, #8.